### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,13 +53,13 @@ Example
    :target: https://coveralls.io/r/themattrix/python-pollute
 .. |Health| image:: https://landscape.io/github/themattrix/python-pollute/master/landscape.svg
    :target: https://landscape.io/github/themattrix/python-pollute/master
-.. |Version| image:: https://pypip.in/version/pollute/badge.svg?text=version
+.. |Version| image:: https://img.shields.io/pypi/v/pollute.svg?label=version
     :target: https://pypi.python.org/pypi/pollute
-.. |Downloads| image:: https://pypip.in/download/pollute/badge.svg
+.. |Downloads| image:: https://img.shields.io/pypi/dm/pollute.svg
     :target: https://pypi.python.org/pypi/pollute
-.. |Compatibility| image:: https://pypip.in/py_versions/pollute/badge.svg
+.. |Compatibility| image:: https://img.shields.io/pypi/pyversions/pollute.svg
     :target: https://pypi.python.org/pypi/pollute
-.. |Implementations| image:: https://pypip.in/implementation/pollute/badge.svg
+.. |Implementations| image:: https://img.shields.io/pypi/implementation/pollute.svg
     :target: https://pypi.python.org/pypi/pollute
-.. |Format| image:: https://pypip.in/format/pollute/badge.svg
+.. |Format| image:: https://img.shields.io/pypi/format/pollute.svg
     :target: https://pypi.python.org/pypi/pollute


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pollute))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pollute`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.